### PR TITLE
support hierachical key

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ By using Cellar, you don't need to trust the cloud provider to store your passwo
 
 Cellar is a MVP at the moment. Some future items:
 
+* [*] support hierarchical keys
 * [ ] generate password by a set of rules (min / max / character set)
 * [ ] record the app_info and the rule it uses in an encrypted file
 * [ ] provide a WebUI to make it easy to use
@@ -50,12 +51,31 @@ Note that even if you regenerate the cellar with the same password you will get 
 
 ### cellar generate
 
-Generate an application password.
+Generate an application password:
 
 ```bash
 $ cellar generate --app-info "user@gmail.com"
 Password: [hidden]
 Password for user@gmail.com: FLugCDPDQ5NP_Nb0whUMwY2YD3wMWqoGcoywqqZ_JSU
+```
+
+Generate hierarchical keys:
+
+```bash
+# generate parent key
+$ cellar generate -i "apps"
+Password: [hidden]
+Key for apps: 6CAakhEv_L2purgTfUasrvA9qgRZrQGdETDohSbBvNI
+
+# generate app key by using parent key
+$ cellar generate -i "my/awesome/app" --use-parent-key
+Parent Key: [hidden]
+Key for my/awesome/app: ZFqgQZK4Sx4GgwLn9D-qmhYE5gw0QbUSl4I8HaTseZs
+
+# it would be the same as generate the whole hierarchical key with master password
+$ cellar generate -i "apps/my/awesome/app"
+Password: [hidden]
+Key for apps/my/awesome/app: ZFqgQZK4Sx4GgwLn9D-qmhYE5gw0QbUSl4I8HaTseZs
 ```
 
 ## Benchmark

--- a/cellar-core/Cargo.toml
+++ b/cellar-core/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.7"
 rust-argon2 = "0.6"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
+zeroize = { version = "1", features = ["zeroize_derive"]}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/cellar-core/Cargo.toml
+++ b/cellar-core/Cargo.toml
@@ -8,7 +8,7 @@ name = "cellar-core"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create git tag.
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Tyr Chen <tyr.chen@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/cellar/Cargo.toml
+++ b/cellar/Cargo.toml
@@ -8,7 +8,7 @@ name = "cellar"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create git tag.
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Tyr Chen <tyr.chen@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -28,8 +28,8 @@ keywords = ["password", "security", "cryptography"]
 [dependencies]
 anyhow = "1"
 base64 = "0.11"
-cellar-core = { path = "../cellar-core" }
-# cellar-core = "0.1.1"
+# cellar-core = { path = "../cellar-core" }
+cellar-core = "0.2.0"
 dialoguer = "0.5"
 dirs = "2"
 structopt = "0.3"

--- a/cellar/Cargo.toml
+++ b/cellar/Cargo.toml
@@ -28,8 +28,8 @@ keywords = ["password", "security", "cryptography"]
 [dependencies]
 anyhow = "1"
 base64 = "0.11"
-# cellar-core = { path = "../cellar-core" }
-cellar-core = "0.1.1"
+cellar-core = { path = "../cellar-core" }
+# cellar-core = "0.1.1"
 dialoguer = "0.5"
 dirs = "2"
 structopt = "0.3"

--- a/cellar/src/main.rs
+++ b/cellar/src/main.rs
@@ -51,7 +51,8 @@ fn main() -> Result<()> {
                 config_file: ConfigFile { name },
                 app_info,
                 key_type,
-            } => commands::generate(&name, &app_info, key_type).await,
+                use_parent_key,
+            } => commands::generate(&name, &app_info, key_type, use_parent_key).await,
         }
     };
 


### PR DESCRIPTION
## Add zeroize

Now the returned keys are wrapped with `Zeroizing` to make the keys safe in memory.

## Support hierarchical key

Generate hierarchical keys like this:

```bash
# generate parent key
$ cellar generate -i "apps"
Password: [hidden]
Key for apps: 6CAakhEv_L2purgTfUasrvA9qgRZrQGdETDohSbBvNI

# generate app key by using parent key
$ cellar generate -i "my/awesome/app" --use-parent-key
Parent Key: [hidden]
Key for my/awesome/app: ZFqgQZK4Sx4GgwLn9D-qmhYE5gw0QbUSl4I8HaTseZs

# it would be the same as generate the whole hierarchical key with master password
$ cellar generate -i "apps/my/awesome/app"
Password: [hidden]
Key for apps/my/awesome/app: ZFqgQZK4Sx4GgwLn9D-qmhYE5gw0QbUSl4I8HaTseZs
```